### PR TITLE
Configurable presets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,21 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.39.0",
+        "@anthropic-ai/sdk": "~0.39.0",
+        "@inquirer/prompts": "^7.4.0",
         "chalk": "^5.4.1",
         "dotenv": "^16.4.7",
-        "enquirer": "^2.4.1",
         "figlet": "^1.8.0",
         "ora": "^8.2.0"
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
-        "@types/figlet": "^1.5.8",
-        "@types/node": "^20.11.20",
+        "@types/figlet": "^1.7.0",
+        "@types/node": "^20.0",
         "typescript": "^5.3.3"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -39,9 +42,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
-      "version": "18.19.81",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.81.tgz",
-      "integrity": "sha512-7KO9oZ2//ivtSsryp0LQUqq79zyGXzwq1WqfywpC9ucjY7YyltMMmxWgtRFRKCxwa7VPxVBVy4kHf5UC1E8Lug==",
+      "version": "18.19.84",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.84.tgz",
+      "integrity": "sha512-ACYy2HGcZPHxEeWTqowTF7dhXN+JU1o7Gr4b41klnn6pj2LD6rsiGqSZojMdk1Jh2ys3m76ap+ae1vvE4+5+vg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -217,6 +220,310 @@
         "node": ">=14.21.3"
       }
     },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.4.tgz",
+      "integrity": "sha512-d30576EZdApjAMceijXA5jDzRQHT/MygbC+J8I7EqA6f/FRpYxlRtRJbHF8gHeWYeSdOuTEJqonn7QLB1ELezA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.5",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.8.tgz",
+      "integrity": "sha512-dNLWCYZvXDjO3rnQfk2iuJNL4Ivwz/T2+C3+WnNfJKsNGSuOs3wAo2F6e0p946gtSAk31nZMfW+MRmYaplPKsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.9.tgz",
+      "integrity": "sha512-sXhVB8n20NYkUBfDYgizGHlpRVaCRjtuzNZA6xpALIUbkgfd2Hjz+DfEN6+h1BRnuxw0/P4jCIMjMsEOAMwAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.5",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.9.tgz",
+      "integrity": "sha512-8HjOppAxO7O4wV1ETUlJFg6NDjp/W2NP5FB9ZPAcinAlNT4ZIWOLe2pUVwmmPRSV0NMdI5r/+lflN55AwZOKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5",
+        "external-editor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.11.tgz",
+      "integrity": "sha512-OZSUW4hFMW2TYvX/Sv+NnOZgO8CHT2TU1roUCUIF2T+wfw60XFRRp9MRUPCT06cRnKL+aemt2YmTWwt7rOrNEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
+      "integrity": "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.8.tgz",
+      "integrity": "sha512-WXJI16oOZ3/LiENCAxe8joniNp8MQxF6Wi5V+EBbVA0ZIOpFcL4I9e7f7cXse0HJeIPCWO8Lcgnk98juItCi7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.11.tgz",
+      "integrity": "sha512-pQK68CsKOgwvU2eA53AG/4npRTH2pvs/pZ2bFvzpBhrznh8Mcwt19c+nMO7LHRr3Vreu1KPhNBF3vQAKrjIulw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.11.tgz",
+      "integrity": "sha512-dH6zLdv+HEv1nBs96Case6eppkRggMe8LoOTl30+Gq5Wf27AO/vHFgStTVz4aoevLdNXqwE23++IXGw4eiOXTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5",
+        "ansi-escapes": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.4.0.tgz",
+      "integrity": "sha512-EZiJidQOT4O5PYtqnu1JbF0clv36oW2CviR66c7ma4LsupmmQlUwmdReGKRp456OWPWMz3PdrPiYg3aCk3op2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.1.4",
+        "@inquirer/confirm": "^5.1.8",
+        "@inquirer/editor": "^4.2.9",
+        "@inquirer/expand": "^4.0.11",
+        "@inquirer/input": "^4.1.8",
+        "@inquirer/number": "^3.0.11",
+        "@inquirer/password": "^4.0.11",
+        "@inquirer/rawlist": "^4.0.11",
+        "@inquirer/search": "^3.0.11",
+        "@inquirer/select": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.11.tgz",
+      "integrity": "sha512-uAYtTx0IF/PqUAvsRrF3xvnxJV516wmR6YVONOmCWJbbt87HcDHLfL9wmBQFbNJRv5kCjdYKrZcavDkH3sVJPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.11.tgz",
+      "integrity": "sha512-9CWQT0ikYcg6Ls3TOa7jljsD7PgjcsYEM0bYE+Gkz+uoW9u8eaJCRHJKkucpRE5+xKtaaDbrND+nPDoxzjYyew==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.5",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.1.0.tgz",
+      "integrity": "sha512-z0a2fmgTSRN+YBuiK1ROfJ2Nvrpij5lVN3gPDkQGhavdvIVGHGW29LwYZfM/j42Ai2hUghTI/uoBuTbrJk42bA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.5",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.5.tgz",
+      "integrity": "sha512-ZJpeIYYueOz/i/ONzrfof8g89kNdO2hjGuvULROo3O8rlB2CRtSseE5KeirnyE4t/thAn/EwvS/vuQeJCn+NZg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@types/figlet": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@types/figlet/-/figlet-1.7.0.tgz",
@@ -225,9 +532,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.17.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.25.tgz",
-      "integrity": "sha512-bT+r2haIlplJUYtlZrEanFHdPIZTeiMeh/fSOEbOOfWf9uTn+lg8g0KU6Q3iMgjd9FLuuMAgfCNSkjUbxL6E3Q==",
+      "version": "20.17.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.28.tgz",
+      "integrity": "sha512-DHlH/fNL6Mho38jTy7/JT7sn2wnXI+wULR6PV4gy4VHLVvnrV/d3pHAMQHhc4gjdLmK2ZiPoMxzp6B3yRajLSQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -267,22 +574,46 @@
         "node": ">= 8.0.0"
       }
     },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
       "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "license": "MIT",
       "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/asynckit": {
@@ -316,6 +647,12 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "license": "MIT"
+    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -342,6 +679,33 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -396,19 +760,6 @@
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "license": "MIT"
     },
-    "node_modules/enquirer": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
-      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-colors": "^4.1.1",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -461,6 +812,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/figlet": {
@@ -627,6 +992,27 @@
         "ms": "^2.0.0"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-interactive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
@@ -727,6 +1113,15 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -804,31 +1199,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ora/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/ora/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/restore-cursor": {
@@ -846,6 +1223,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
@@ -888,19 +1271,7 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
+    "node_modules/strip-ansi": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
@@ -915,16 +1286,16 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^5.0.1"
+        "os-tmpdir": "~1.0.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=0.6.0"
       }
     },
     "node_modules/tr46": {
@@ -932,6 +1303,18 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/typescript": {
       "version": "5.8.2",
@@ -976,6 +1359,73 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "chalk": "^5.4.1",
         "dotenv": "^16.4.7",
         "figlet": "^1.8.0",
-        "ora": "^8.2.0"
+        "ora": "^8.2.0",
+        "zod": "^3.24.2"
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
@@ -1426,6 +1427,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Simulate meetings with AI agents using Claude API",
   "main": "dist/index.js",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "prebuild": "npm run format",
     "build": "tsc",
@@ -24,17 +27,17 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.39.0",
+    "@anthropic-ai/sdk": "~0.39.0",
+    "@inquirer/prompts": "^7.4.0",
     "chalk": "^5.4.1",
     "dotenv": "^16.4.7",
-    "enquirer": "^2.4.1",
     "figlet": "^1.8.0",
     "ora": "^8.2.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
-    "@types/figlet": "^1.5.8",
-    "@types/node": "^20.11.20",
+    "@types/figlet": "^1.7.0",
+    "@types/node": "^20.0",
     "typescript": "^5.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "chalk": "^5.4.1",
     "dotenv": "^16.4.7",
     "figlet": "^1.8.0",
-    "ora": "^8.2.0"
+    "ora": "^8.2.0",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,11 +15,13 @@ interface AgendaFileData {
   agenda: string[];
 }
 
-interface Defaults {
-  involvement: string;
-  lowEndModel: string;
-  highEndModel: string;
-}
+const defaultsSchema = z.object({
+  involvement: z.enum(['none', 'low', 'high']),
+  lowEndModel: z.string(),
+  highEndModel: z.string(),
+});
+
+type Defaults = z.infer<typeof defaultsSchema>;
 
 const saveFile = '.headsinjars.json';
 
@@ -42,6 +44,7 @@ import { availablePersonas } from './personas.js';
 // Import UI utilities
 import { debugLog } from './utils/formatting.js';
 
+import { z } from 'zod';
 import { AnthropicClient } from './api/index.js';
 // Import types
 import type { PersonaDirectory, PersonaInfo } from './types.js';
@@ -461,7 +464,13 @@ function loadDefaults(): Defaults | undefined {
     return undefined;
   }
   const file = fs.readFileSync(saveFile, 'utf8');
-  return JSON.parse(file);
+  try {
+    const json = JSON.parse(file);
+    return defaultsSchema.parse(json);
+  } catch (e: unknown) {
+    console.error(chalk.red(`Defaults file at ${saveFile} is invalid, ignoring...you may wish to remove it`));
+    return undefined;
+  }
 }
 
 main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ const saveFile = '.headsinjars.json';
 // Check for command line arguments
 const isValidationMode = process.argv.includes('--validate');
 const isDebugMode = process.argv.includes('--debug');
+const skipSetup = process.argv.includes('--skip-setup');
 
 // Check for agenda file argument
 const agendaFileArg = process.argv.find((arg) => arg.startsWith('--agenda-file='));
@@ -178,76 +179,78 @@ async function main(): Promise<void> {
       | 'save_and_continue'
       | 'continue';
 
-    outer: while (true) {
-      const nextAction: actions = await select({
-        message: 'Setup',
-        loop: false,
-        pageSize: 99,
-        default: 'continue' satisfies actions,
-        choices: [
-          {
-            value: 'involvement',
-            name: 'Level of involvement',
-            description: involvement,
-          },
-          {
-            value: 'select_cheap_model',
-            name: 'Cheap model',
-            description: cheapModel,
-          },
-          {
-            value: 'select_good_model',
-            name: 'Good model',
-            description: goodModel,
-          },
-          new Separator(),
-          {
-            value: 'save_and_continue',
-            name: 'Save as default and continue',
-          },
-          {
-            value: 'continue',
-            name: 'Continue',
-          },
-        ],
-      });
+    if (!skipSetup) {
+      outer: while (true) {
+        const nextAction: actions = await select({
+          message: 'Setup',
+          loop: false,
+          pageSize: 99,
+          default: 'continue' satisfies actions,
+          choices: [
+            {
+              value: 'involvement',
+              name: 'Level of involvement',
+              description: involvement,
+            },
+            {
+              value: 'select_cheap_model',
+              name: 'Cheap model',
+              description: cheapModel,
+            },
+            {
+              value: 'select_good_model',
+              name: 'Good model',
+              description: goodModel,
+            },
+            new Separator(),
+            {
+              value: 'save_and_continue',
+              name: 'Save as default and continue',
+            },
+            {
+              value: 'continue',
+              name: 'Continue',
+            },
+          ],
+        });
 
-      switch (nextAction) {
-        case 'involvement':
-          involvement = await select({
-            message: 'Select your level of involvement in the meeting:',
+        switch (nextAction) {
+          case 'involvement':
+            involvement = await select({
+              message: 'Select your level of involvement in the meeting:',
 
-            choices: [
-              { value: 'none', name: 'None - Just observe the meeting' },
-              { value: 'low', name: 'Low - Occasional input' },
-              { value: 'high', name: 'High - Frequent opportunities to speak' },
-            ],
-          });
-          break;
-        case 'select_cheap_model':
-          cheapModel = await input({
-            message: 'Select cheap model',
-            required: true,
-            default: defaultLowEndModel,
-          });
-          break;
-        case 'select_good_model':
-          goodModel = await input({
-            message: 'Select good model',
-            required: true,
-            default: defaultHighEndModel,
-          });
-          break;
-        case 'save_and_continue':
-          saveDefaults({
-            involvement,
-            lowEndModel: cheapModel,
-            highEndModel: goodModel,
-          });
-          console.log(chalk.green(`Defaults saved to ${chalk.bold(saveFile)}`));
-          break outer;
-        case 'continue':
-          break outer;
+              choices: [
+                { value: 'none', name: 'None - Just observe the meeting' },
+                { value: 'low', name: 'Low - Occasional input' },
+                { value: 'high', name: 'High - Frequent opportunities to speak' },
+              ],
+            });
+            break;
+          case 'select_cheap_model':
+            cheapModel = await input({
+              message: 'Select cheap model',
+              required: true,
+              default: defaultLowEndModel,
+            });
+            break;
+          case 'select_good_model':
+            goodModel = await input({
+              message: 'Select good model',
+              required: true,
+              default: defaultHighEndModel,
+            });
+            break;
+          case 'save_and_continue':
+            saveDefaults({
+              involvement,
+              lowEndModel: cheapModel,
+              highEndModel: goodModel,
+            });
+            console.log(chalk.green(`Defaults saved to ${chalk.bold(saveFile)}`));
+            break outer;
+          case 'continue':
+            break outer;
+        }
       }
     }
 

--- a/src/meeting.ts
+++ b/src/meeting.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { input } from '@inquirer/prompts';
 import chalk from 'chalk';
 import ora from 'ora';
 import { Agent, ModeratorAgent } from './agents.js';
@@ -6,7 +7,6 @@ import type { AnthropicClient } from './api/client.js';
 import type { MeetingSimulatorOptions, Message, PersonaDirectory, PersonaInfo } from './types.js';
 import { createMessage, sleep } from './utils.js';
 import { debugLog } from './utils/index.js';
-import { input } from '@inquirer/prompts';
 
 /**
  * Class for simulating a meeting with AI agents

--- a/src/meeting.ts
+++ b/src/meeting.ts
@@ -1,16 +1,12 @@
 import fs from 'node:fs';
 import chalk from 'chalk';
-// Import enquirer as ESM
-import Enquirer from 'enquirer';
 import ora from 'ora';
-// Access Input class dynamically
-// biome-ignore lint/suspicious/noExplicitAny: Enquirer doesn't have proper types
-const Input = (Enquirer as any).Input;
 import { Agent, ModeratorAgent } from './agents.js';
 import type { AnthropicClient } from './api/client.js';
 import type { MeetingSimulatorOptions, Message, PersonaDirectory, PersonaInfo } from './types.js';
 import { createMessage, sleep } from './utils.js';
 import { debugLog } from './utils/index.js';
+import { input } from '@inquirer/prompts';
 
 /**
  * Class for simulating a meeting with AI agents
@@ -271,11 +267,9 @@ export class MeetingSimulator {
 
       if (userTurn) {
         console.log(chalk.cyan('\n🎯 Your turn to speak:'));
-        const userInput = await new Input({
-          name: 'input',
+        const userInput = await input({
           message: chalk.cyanBright.bold('💬 You:'),
-          initial: '',
-        }).run();
+        });
 
         if (['exit', 'quit', 'end meeting'].includes(userInput.toLowerCase())) {
           console.log(chalk.cyan('\n=== Ending Meeting Early ===\n'));
@@ -590,11 +584,9 @@ export class MeetingSimulator {
           turnsSinceUserInput += 1;
         } else {
           // User interrupted, let them speak
-          const userInput = await new Input({
-            name: 'input',
+          const userInput = await input({
             message: chalk.yellowBright.bold('🙋 You:'),
-            initial: '',
-          }).run();
+          });
 
           if (['exit', 'quit', 'end meeting'].includes(userInput.toLowerCase())) {
             console.log(chalk.cyan('\n=== Ending Meeting Early ===\n'));

--- a/src/meeting/simulator.ts
+++ b/src/meeting/simulator.ts
@@ -1,3 +1,4 @@
+import { input } from '@inquirer/prompts';
 import chalk from 'chalk';
 import { Agent } from '../agents/agent.js';
 import { ModeratorAgent } from '../agents/moderator.js';
@@ -11,7 +12,6 @@ import { debugLog, sleep } from '../utils/index.js';
 import { ConversationManager } from './conversation.js';
 import { selectNextSpeaker } from './speaker.js';
 import { saveTranscript as saveTranscriptToFile } from './transcript.js';
-import { input } from '@inquirer/prompts';
 
 /**
  * Class for simulating a meeting with AI agents

--- a/src/meeting/simulator.ts
+++ b/src/meeting/simulator.ts
@@ -1,12 +1,4 @@
-/**
- * Meeting Simulator class
- */
-
 import chalk from 'chalk';
-import Enquirer from 'enquirer';
-// Access Input class dynamically
-// biome-ignore lint/suspicious/noExplicitAny: Enquirer doesn't have proper types
-const Input = (Enquirer as any).Input;
 import { Agent } from '../agents/agent.js';
 import { ModeratorAgent } from '../agents/moderator.js';
 import type { AnthropicClient, MessageParams } from '../api/client.js';
@@ -19,6 +11,7 @@ import { debugLog, sleep } from '../utils/index.js';
 import { ConversationManager } from './conversation.js';
 import { selectNextSpeaker } from './speaker.js';
 import { saveTranscript as saveTranscriptToFile } from './transcript.js';
+import { input } from '@inquirer/prompts';
 
 /**
  * Class for simulating a meeting with AI agents
@@ -303,11 +296,9 @@ export class MeetingSimulator {
 
       if (userTurn) {
         console.log(chalk.cyan('\n🎯 Your turn to speak:'));
-        const userInput = await new Input({
-          name: 'input',
+        const userInput = await input({
           message: chalk.cyanBright.bold('💬 You:'),
-          initial: '',
-        }).run();
+        });
 
         if (['exit', 'quit', 'end meeting'].includes(userInput.toLowerCase())) {
           await this.endMeetingEarly();
@@ -451,11 +442,9 @@ export class MeetingSimulator {
       }
     } else {
       // User interrupted, let them speak
-      const userInput = await new Input({
-        name: 'input',
+      const userInput = await input({
         message: chalk.yellowBright.bold('🙋 You:'),
-        initial: '',
-      }).run();
+      });
 
       if (['exit', 'quit', 'end meeting'].includes(userInput.toLowerCase())) {
         await this.endMeetingEarly();


### PR DESCRIPTION
This implements the following:
* Creates a simple setup menu for navigating through and updating the one-time setup options.
* Saves those setup options to a file, and reads them on startup. Includes validation.
* Added a flag for bypassing setup (and using the defaults).
* Incidentally, also switched to `@inquirer/prompts`.